### PR TITLE
Remove Rails 4.2.0 lock, bump version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    clark_kent (0.2.7)
+    clark_kent (0.2.9)
       aws-sdk (< 2)
       foreign_office (>= 0.10.3, < 0.12)
       hooch (>= 0.7.1, < 1.0)
       kaminari (< 1)
-      rails (= 4.2.0, < 5)
+      rails (< 5)
       sass-rails (< 5.1)
       simple_form (>= 3.2.1, < 4.0)
       thin_man (>= 0.12.2, < 0.13)
@@ -124,7 +124,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.5.0)
     request_store (1.3.0)
-    sass (3.4.21)
+    sass (3.4.22)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)

--- a/clark_kent.gemspec
+++ b/clark_kent.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "4.2.0", "< 5"
+  s.add_dependency "rails", "< 5"
   s.add_dependency "sass-rails", "< 5.1"
   s.add_dependency "simple_form", ">= 3.2.1", "< 4.0"
   s.add_dependency "kaminari", "< 1"

--- a/lib/clark_kent/version.rb
+++ b/lib/clark_kent/version.rb
@@ -1,3 +1,3 @@
 module ClarkKent
-  VERSION = "0.2.8"
+  VERSION = "0.2.9"
 end


### PR DESCRIPTION
Rails 4.2.0 lock is preventing us from upgrading to 4.2.6 on InvitedHome