### PR TITLE
Map sorting hash correctly

### DIFF
--- a/app/models/clark_kent/report.rb
+++ b/app/models/clark_kent/report.rb
@@ -4,7 +4,7 @@ module ClarkKent
   class Report < ActiveRecord::Base
     include ClarkKent::Cloneable
 
-    SortDirections = {'A->Z' => 'asc', 'Z->A' => 'desc'}
+    SortDirections = {'ascending' => 'asc', 'descending' => 'desc'}
 
     attr_accessor :summary_row_storage
 


### PR DESCRIPTION
The problem was that in the ReportColumn object is saving the report_sort column as "descending/ascending" and not "A->Z/Z->A" string this should fix it